### PR TITLE
Fix invalid redispatch3.0 image path

### DIFF
--- a/research.html
+++ b/research.html
@@ -81,7 +81,7 @@
           <div class="project-text">
             <h3 class="h3">Redispatch</h3>
             <p class="paragraph">With the high penetration of distributed energy resources (DERs), the regulatory framework and grid operation procedure were adjusted in the amendment to the Grid Expansion Acceleration Act (NABEG 2.0). Involving the DSOs in congestion management is an important step in implementing the so-called “Redispatch”. These aim to avoid grid bottlenecks across all grid levels and thus make them more efficient, economical, and resilient.<br><br>The project “Redispatch 3.0” aims to improve the integration of low-voltage plants as well as the cooperation and exchange of information between DSOs and with TSOs. The goal is to further develop existing concepts for Redispatch 2.0 and to implement, test, and evaluate the approaches developed on a pilot basis.</p>
-            <a href="#" class="ghost-button grey w-button">Learn More</a>
+            <a href="https://ie3.etit.tu-dortmund.de/research/third-party-projects/distribution-grid-planning-operation/redispatch-30/" target="_blank" class="ghost-button w-button">Learn More</a>
           </div>
         </div>
         <div class="h-flex mb-150">

--- a/research.html
+++ b/research.html
@@ -71,9 +71,9 @@
         </div>
         <div class="h-flex mb-150 left">
           <div class="pr-150 project-logo-section">
-            <a href="https://ie3.etit.tu-dortmund.de/research/third-party-projects/distribution-grid-planning-operation/hola/" class="link-block w-inline-block"><img src="images/logo_redispatch.png" loading="lazy" alt="" class="project-logo"></a>
+            <a href="https://ie3.etit.tu-dortmund.de/research/third-party-projects/distribution-grid-planning-operation/hola/" class="link-block w-inline-block"><img src="images/logo_redispatch3.png" loading="lazy" alt="" class="project-logo"></a>
             <div class="v-flex hashtag-section">
-              <div class="hashtag">#redispatchy</div>
+              <div class="hashtag">#redispatch</div>
               <div class="hashtag mid">#renewable-energy</div>
               <div class="hashtag">#grid-expansion</div>
             </div>


### PR DESCRIPTION
The image path of #7 is broken and I oversaw the missing 3 during the review. Furthermore, there is a typo. 

Additionally this branch added the link for the redispatch3.0 learn more button

This PR fixes both issues. 